### PR TITLE
Academy link

### DIFF
--- a/ods-helphub/src/components/elements/navigation.vue
+++ b/ods-helphub/src/components/elements/navigation.vue
@@ -45,13 +45,6 @@
         </div>
 
         <div class="ods-header__nav-item">
-            <a href="/tutorials/en/"
-                class="ods-nav__link">
-                {{ trad.tutorials[lang] }}
-            </a>
-        </div>
-
-        <div class="ods-header__nav-item">
           <a :href="lang === 'fr' ? 'https://academy.opendatasoft.com/' : 'https://academy.opendatasoft.com/page/homepage'"
               class="ods-nav__link">
               {{ trad.academy[lang] }}

--- a/ods-helphub/src/components/elements/navigation.vue
+++ b/ods-helphub/src/components/elements/navigation.vue
@@ -51,8 +51,15 @@
             </a>
         </div>
 
+        <div class="ods-header__nav-item">
+          <a :href="lang === 'fr' ? 'https://academy.opendatasoft.com/' : 'https://academy.opendatasoft.com/page/homepage'"
+              class="ods-nav__link">
+              {{ trad.academy[lang] }}
+          </a>
+        </div>
+
     </div>
-    
+
 </template>
 
 <script>

--- a/ods-helphub/src/components/pages/home.vue
+++ b/ods-helphub/src/components/pages/home.vue
@@ -38,8 +38,8 @@
             :isHref="false"/>
 
         <boxes :lang="lang"
-            :trad="trad.tutorials"
-            :img="img.tutorial"
+            :trad="trad.academy"
+            :img="img.discovery"
             :sizeBox="classSizeBox"
             :sizeIcon="classSizeIcon"
             :isHref="true"/>
@@ -51,12 +51,6 @@
             :sizeIcon="classSizeIcon"
             :isHref="true"/>
 
-        <boxes :lang="lang"
-            :trad="trad.academy"
-            :img="img.discovery"
-            :sizeBox="classSizeBox"
-            :sizeIcon="classSizeIcon"
-            :isHref="true"/>
 
     </div>
 

--- a/ods-helphub/src/components/pages/home.vue
+++ b/ods-helphub/src/components/pages/home.vue
@@ -1,7 +1,7 @@
 <template>
 
     <div class="ods-container">
-            
+
         <boxes :lang="lang"
             :trad="trad.platform"
             :img="img.platform"
@@ -43,10 +43,17 @@
             :sizeBox="classSizeBox"
             :sizeIcon="classSizeIcon"
             :isHref="true"/>
-        
+
         <boxes :lang="lang"
             :trad="trad.support"
             :img="img.support"
+            :sizeBox="classSizeBox"
+            :sizeIcon="classSizeIcon"
+            :isHref="true"/>
+
+        <boxes :lang="lang"
+            :trad="trad.academy"
+            :img="img.discovery"
             :sizeBox="classSizeBox"
             :sizeIcon="classSizeIcon"
             :isHref="true"/>

--- a/ods-helphub/src/translations/app.js
+++ b/ods-helphub/src/translations/app.js
@@ -59,7 +59,7 @@ export default {
 
     academy: {
         en: "Academy",
-        fr: "Académie",
+        fr: "Academy",
         es: "Academy",
         de: "Academy",
         nl: "Academy"

--- a/ods-helphub/src/translations/app.js
+++ b/ods-helphub/src/translations/app.js
@@ -57,6 +57,14 @@ export default {
         nl: "Tutorials"
     },
 
+    academy: {
+        en: "Academy",
+        fr: "Académie",
+        es: "Academy",
+        de: "Academy",
+        nl: "Academy"
+    },
+
     btn_menu: {
         en: "Help Hub",
         fr: "Help Hub",

--- a/ods-helphub/src/translations/home.js
+++ b/ods-helphub/src/translations/home.js
@@ -187,7 +187,7 @@ export default {
             es: "Academy",
             de: "Academy",
             nl: "Academy",
-            fr: "Académie"
+            fr: "Academy"
         },
         desc: {
             en: "Build and advance your skills as an Opendatasoft user and grow your data sharing expertise thanks to our courses and learning resources.",

--- a/ods-helphub/src/translations/home.js
+++ b/ods-helphub/src/translations/home.js
@@ -180,6 +180,32 @@ export default {
 
     },
 
+    academy: {
+
+        title: {
+            en: "Academy",
+            es: "Academy",
+            de: "Academy",
+            nl: "Academy",
+            fr: "Académie"
+        },
+        desc: {
+            en: "Build and advance your skills as an Opendatasoft user and grow your data sharing expertise thanks to our courses and learning resources.",
+            es: "Build and advance your skills as an Opendatasoft user and grow your data sharing expertise thanks to our courses and learning resources.",
+            de: "Build and advance your skills as an Opendatasoft user and grow your data sharing expertise thanks to our courses and learning resources.",
+            nl: "Build and advance your skills as an Opendatasoft user and grow your data sharing expertise thanks to our courses and learning resources.",
+            fr: "Devenez un power user de la plateforme Opendatasoft et développez votre expertise du partage de données grâce à nos cours et nos ressources pédagogiques."
+        },
+        url: {
+            fr: "https://academy.opendatasoft.com/",
+            en: "https://academy.opendatasoft.com/page/homepage",
+            es: "https://academy.opendatasoft.com/page/homepage",
+            de: "https://academy.opendatasoft.com/page/homepage",
+            nl: "https://academy.opendatasoft.com/page/homepage"
+        }
+
+    },
+
     support: {
         title: {
             en: "Support",

--- a/ods-tutorial/source/_templates/header.html
+++ b/ods-tutorial/source/_templates/header.html
@@ -31,6 +31,9 @@
             <div class="ods__documentation-header-nav-item ods__documentation-header-nav-item-active">
                 <a href="{{ pathto(master_doc) }}">{{ gettext('Tutorials') }}</a>
             </div>
+            <div class="ods__documentation-header-nav-item">
+                <a href="https://academy.opendatasoft.com/page/homepage">Academy</a>
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
Add links to academy in both pages. Behavior is not consistent between headers/cards/tutorial headers, but it's "as good as the others". No icons for homepage card 👉 used the same as Discovery (not worth designing a new one before help hub revamp)