### PR TITLE
Link to release notes in navigation header

### DIFF
--- a/ods-helphub/src/components/elements/navigation.vue
+++ b/ods-helphub/src/components/elements/navigation.vue
@@ -51,7 +51,7 @@
           </a>
         </div>
 
-                <div class="ods-header__nav-item">
+        <div class="ods-header__nav-item">
             <a href="https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true"
                 class="ods-nav__link">
                 {{ trad.releasenotes[lang] }}

--- a/ods-helphub/src/components/elements/navigation.vue
+++ b/ods-helphub/src/components/elements/navigation.vue
@@ -51,6 +51,13 @@
           </a>
         </div>
 
+                <div class="ods-header__nav-item">
+            <a href="https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true"
+                class="ods-nav__link">
+                {{ trad.releasenotes[lang] }}
+            </a>
+        </div>
+
     </div>
 
 </template>

--- a/ods-helphub/src/translations/app.js
+++ b/ods-helphub/src/translations/app.js
@@ -65,6 +65,14 @@ export default {
         nl: "Academy"
     },
 
+    releasenotes: {
+        en: "Release notes",
+        fr: "Notes de version",
+        es: "Notas de la versión",
+        de: "Veröffentlichungshinweise",
+        nl: "Nota's vrijgeven"
+    },
+
     btn_menu: {
         en: "Help Hub",
         fr: "Help Hub",

--- a/ods-tutorial/source/_templates/header.html
+++ b/ods-tutorial/source/_templates/header.html
@@ -34,6 +34,9 @@
             <div class="ods__documentation-header-nav-item">
                 <a href="https://academy.opendatasoft.com/page/homepage">Academy</a>
             </div>
+            <div class="ods__documentation-header-nav-item">
+                <a href="https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true">{{ gettext('Release notes') }}</a>
+            </div>
         </div>
 
     </div>


### PR DESCRIPTION
## Summary

This PR adds a link to the [release notes](https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true) in the navigation header, so that users can access this page from the help hub's home page.

Story details: https://app.clubhouse.io/opendatasoft/story/26719

## Changes

- Added a new link to the release notes in the navigation header.
- Added translations.
- Created a "key", so that the "Release notes" link text gets translated in the tutorials page.